### PR TITLE
Fixed error when user sets their email to stay the same

### DIFF
--- a/controllers/user.controller.js
+++ b/controllers/user.controller.js
@@ -94,9 +94,13 @@ const verifyUser = async (req, res) => {
 const setUserInfo = async (req, res) => {
   try {
     let userFound = await User.findOne({ _id: req.params.userId });
+    let userSameEmail = await User.findOne({ email: req.body.email });
 
-    if (req.body.email && User.findOne(req.body.email)) {
-      if (userFound.email === req.body.email) {
+    if (req.body.email && userSameEmail.email) {
+      if (
+        userFound.email === req.body.email &&
+        userFound.userId !== userSameEmail.userId
+      ) {
         return res.status(400).json({
           error: "Email already taken. Please try again.", // assure that it is not the same email
         });


### PR DESCRIPTION
<!--- BEFORE SUBMITTING YOUR PR, CHECK THAT: --->
<!--- 1) Your PR has a descriptive name --->
<!--- 2) This PR template is filled out --->
<!--- 3) You wrote tests for your change --->

# Fixed Edit Profile Button
<!--- Put the issue number here. --->
Closes #202

# Summary of change
<!--- Describe the change that this pull request makes. --->
<!--- Add screenshots here if relevant --->
- Fixed on setUserInfo route.
- Discovered that the condition for preventing users from linking multiple accounts to the same email was incorrect.
- Now compares if the user with the same email has the same ID as the user requesting the change (thus the user is not actually changing their email) and proceeds to update user info.

# Testing/Verification
<!--- How did you test your change? Reference any files you changed/added here. --->
- Submitting a form through edit profile under the Profile tab in the MyAccount page should work now!
