### PR TITLE
Protected container routes, added login auth and logout functionality for admin-dashboard

### DIFF
--- a/controllers/adminVerification.controller.js
+++ b/controllers/adminVerification.controller.js
@@ -1,4 +1,5 @@
 const jwt = require("jsonwebtoken");
+const RefreshToken = require("../models/refreshToken.model");
 
 const PASSWORD = process.env.ADMIN_PASSWORD;
 const JWT_SECRET = process.env.JWT_SECRET;
@@ -11,10 +12,87 @@ const verify = async (req, res) => {
     const token = await jwt.sign({ type: "admin" }, JWT_SECRET, {
       expiresIn: JWT_EXPIRE,
     });
-    res.status(200).json({ success: true, token });
+    const refreshToken = await jwt.sign({ type: "admin" }, JWT_SECRET);
+
+    //Keeping record of newly created refresh tokens in MongoDB.
+    const refreshTokenDB = new RefreshToken({
+      refreshToken: refreshToken,
+    });
+    try {
+      await refreshTokenDB.save();
+    } catch (err) {
+      console.log(err);
+    }
+
+    res.status(200).json({ success: true, token, refreshToken });
   } else {
     res.status(400).json({ errors: "Password Incorrect" });
   }
 };
 
-module.exports = { verify };
+const verifyToken = async (req, res, next) => {
+  //Retrives the access and refresh token from the request header.
+  const token = req.headers["authorization"].split(" ")[1];
+  const refreshToken = req.headers["refreshtoken"];
+
+  //Checks that access and refresh tokens exist before jwt verification.
+  if (token === null || refreshToken === null) return res.sendStatus(401);
+  if ((await RefreshToken.find({ refreshToken: refreshToken })).length !== 1)
+    return res.sendStatus(401);
+
+  //Verifies the access token to see if its valid, invalid or expired.
+  try {
+    await jwt.verify(token, JWT_SECRET, (err, user) => {
+      if (err) {
+        //Access token is either invalid or expired, so use refresh token to verify and send new access token
+        jwt.verify(refreshToken, JWT_SECRET, (err, user) => {
+          if (err) {
+            return res.sendStatus(403);
+          } else {
+            const newToken = jwt.sign({ type: "admin" }, JWT_SECRET, {
+              expiresIn: JWT_EXPIRE,
+            });
+            return res.json({
+              status: "Success",
+              expiredToken: true,
+              newToken,
+            });
+          }
+        });
+      } else {
+        return res.json({ status: "Success", expiredToken: false });
+      }
+    });
+  } catch (err) {
+    console.log(err);
+  }
+};
+
+const authAdmin = async (req, res, next) => {
+  const refreshToken = req.headers["refreshtoken"];
+  //Checks that refresh token exists before jwt verification.
+  if (refreshToken == null) return res.sendStatus(401);
+  if ((await RefreshToken.find({ refreshToken: refreshToken })).length !== 1)
+    return res.sendStatus(401);
+
+  //Verifies if the refresh token is valid before providing access to API routes.
+  try {
+    jwt.verify(refreshToken, JWT_SECRET, (err) => {
+      if (err) return res.sendStatus(403);
+      next();
+    });
+  } catch (err) {
+    return res.sendStatus(500);
+  }
+};
+
+const deleteRefreshToken = async (req, res) => {
+  const refreshToken = req.headers["refreshtoken"];
+  //Removes refresh token from mongoDB to prevent renewal of access tokens.
+  await RefreshToken.deleteOne({ refreshToken: refreshToken }, (err) => {
+    if (err) return res.sendStatus(403);
+    return res.sendStatus(200);
+  });
+};
+
+module.exports = { verify, verifyToken, authAdmin, deleteRefreshToken };

--- a/models/refreshToken.model.js
+++ b/models/refreshToken.model.js
@@ -1,0 +1,16 @@
+const mongoose = require("mongoose");
+const Schema = mongoose.Schema;
+
+refreshTokenSchema = new Schema(
+  {
+    refreshToken: {
+      type: String,
+      required: [true, "Refresh token cannot be blank"],
+    },
+  },
+  { timestamps: true }
+);
+
+const RefreshToken = mongoose.model("RefreshToken", refreshTokenSchema);
+
+module.exports = RefreshToken;

--- a/routes/adminVerification.js
+++ b/routes/adminVerification.js
@@ -12,8 +12,21 @@ DESCRIPTION:
 */
 router.post("/", AdminVerification.verify);
 
+/*
+INPUT:
+  Bearer <token> ('Authorization' header) - string access token that is passed by default from admin dashboard. 
+  <refreshToken> - ('RefreshToken' header) string refresh token that is passed by default from admin dashboard.
+DESCRIPTION:
+  Verifies the access token and refreshes the token if it's expired (used in admin dashboard to keep user in session) 
+*/
 router.post("/verifyToken", AdminVerification.verifyToken);
 
+/*
+INPUT:
+  <refreshToken> - ('RefreshToken' header) string refresh token that is passed by default from admin dashboard.
+DESCRIPTION:
+  Removes refresh token from MongoDB to prevent user from continuing their logged in session on admin dashboard.
+*/
 router.post("/logout", AdminVerification.deleteRefreshToken);
 
 module.exports = router;

--- a/routes/adminVerification.js
+++ b/routes/adminVerification.js
@@ -12,4 +12,8 @@ DESCRIPTION:
 */
 router.post("/", AdminVerification.verify);
 
+router.post("/verifyToken", AdminVerification.verifyToken);
+
+router.post("/logout", AdminVerification.deleteRefreshToken);
+
 module.exports = router;

--- a/routes/container.js
+++ b/routes/container.js
@@ -1,6 +1,8 @@
 /* BASE PATH: /container */
 
 const express = require("express");
+const { authAdmin } = require("../controllers/adminVerification.controller");
+// const {  } = require("../controllers/adminVerification.controller");
 const router = express.Router();
 const {
   newContainer,
@@ -18,7 +20,7 @@ INPUT:
 DESCRIPTION:
   creates new listing container
 */
-router.post("/", newContainer);
+router.post("/", authAdmin, newContainer);
 
 /*
 INPUT:
@@ -26,7 +28,7 @@ INPUT:
 DESCRIPTION:
   deletes existing listing container by title
 */
-router.delete("/byTitle", deleteContainer);
+router.delete("/byTitle", authAdmin, deleteContainer);
 
 /*
 INPUT:
@@ -35,7 +37,7 @@ INPUT:
 DESCRIPTION:
   adds listing to listing container specified by title
 */
-router.post("/addListing", addListing);
+router.post("/addListing", authAdmin, addListing);
 
 /*
 INPUT:
@@ -52,7 +54,7 @@ INPUT:
 DESCRIPTION:
   deletes listing from listing container
 */
-router.delete("/deleteListing", deleteListing);
+router.delete("/deleteListing", authAdmin, deleteListing);
 
 /*
 INPUT:


### PR DESCRIPTION
# Relevant issue
Closes #193

# Summary of change
- Added in two new routes /verifyToken and /logout in the /adminVerify route.
- Implemented middleware to verify if access tokens to authorize user logins on admin-dashboard.
- Implemented middleware to authorize API calls to the container routes.
- Added refresh tokens to allow users to keep their sessions on the dashboard after every page refresh.
- Stored refresh tokens in Mongo collection to keep track of active and logged-out users.

# Testing/Verification
<!--- How did you test your change? Reference any files you changed/added here. --->
- On the Admin dashboard try logging in then refreshing the page to see if your token keeps you logged in. Then delete your tokens in local storage and refresh the page again.
- Try to access the protected URLs while at the login page.
- Try putting in fake access and refresh token values in local storage.
- Try accessing any of the following container routes with Postman:
    POST "/"
    DELETE "/byTitle"
    POST "/addListing"
    DELETE "/deleteListing"

