### PR TITLE
House Keeping Data Updates Previous Day Count Correctly Now

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,9 @@ const cron = require("node-cron");
 const path = require("path");
 const { allCronJobs } = require("./helpers/cronJobs.helper");
 
+//For Testing purposes of housekeeping remove after done testing.
+const resetDayCount = require("./config/taskScheduler");
+
 const { DATABASE_URI, environment } = require("./config");
 const loginRouter = require("./routes/login");
 const signUpRouter = require("./routes/signup");
@@ -29,6 +32,9 @@ const pingRouter = require("./routes/ping");
 const housekeepingRouter = require("./routes/housekeeping");
 
 const app = express();
+
+resetDayCount();
+
 app.use(bodyParser.json());
 app.use(cors({ origin: true }));
 app.use(morgan("dev"));

--- a/app.js
+++ b/app.js
@@ -33,8 +33,6 @@ const housekeepingRouter = require("./routes/housekeeping");
 
 const app = express();
 
-resetDayCount();
-
 app.use(bodyParser.json());
 app.use(cors({ origin: true }));
 app.use(morgan("dev"));

--- a/config/taskScheduler.js
+++ b/config/taskScheduler.js
@@ -2,7 +2,7 @@ const Popularity = require("../models/popularity.model");
 const Housekeeping = require("../models/housekeeping.model");
 
 const resetDayCount = async () => {
-  await resetPopularityCount();
+  // await resetPopularityCount();
   await resetHousekeepingCount();
 };
 
@@ -48,21 +48,34 @@ const resetHousekeepingCount = async () => {
     const month = curr.getMonth() + 1; // to deal with javascript off by 1 for month
     const field = month + "/" + date;
 
-    const yesterday = new Date();
-    yesterday.setDate(curr.getDate() - 1);
-    const oldDate = yesterday.getDate();
-    const oldMonth = yesterday.getMonth() + 1;
-    const oldField = oldMonth + "/" + oldDate;
-
     const helperFunc = async (name) => {
       const oldResult = await Housekeeping.findOne({ name });
-      let oldPayload = oldResult.payload[oldField];
-      if (!oldPayload) {
-        oldPayload = 0;
+      let oldIndex = oldResult.payload.length - 1; //Gets the last array element from the payload
+      let oldCount;
+      let oldDay;
+
+      //Checks if there are zero objects in array.
+      if (oldIndex === -1) {
+        oldCount = 0;
+      } else {
+        //Gets the previous object's count in the array.
+        oldCount = oldResult.payload[oldIndex].count;
+        oldDay = oldResult.payload[oldIndex].date;
       }
+
+      /*Prevents the housekeeping from pushing a new object (mostly for testing purposes since the cron job will only run once each day.*/
+      if (field === oldDay) {
+        return;
+      }
+
+      //Pushes a new payload object to keep track of the date and count
       await Housekeeping.findOneAndUpdate(
         { name },
-        { $set: { ["payload." + field]: oldPayload } }
+        {
+          $push: {
+            payload: { date: field, count: oldCount },
+          },
+        }
       );
     };
 

--- a/config/taskScheduler.js
+++ b/config/taskScheduler.js
@@ -2,7 +2,7 @@ const Popularity = require("../models/popularity.model");
 const Housekeeping = require("../models/housekeeping.model");
 
 const resetDayCount = async () => {
-  // await resetPopularityCount();
+  await resetPopularityCount();
   await resetHousekeepingCount();
 };
 

--- a/controllers/housekeeping.controller.js
+++ b/controllers/housekeeping.controller.js
@@ -4,6 +4,8 @@ const getName = async (req, res) => {
   try {
     const { name } = req.params;
     const result = await Housekeeping.findOne({ name });
+    /*This originally sent back the object with all the fields from the payload,
+      but now returns an array of objects as the payload.*/
     res.status(200).json({ payload: result.payload });
   } catch (err) {
     res.status(500).json({

--- a/controllers/listing.controller.js
+++ b/controllers/listing.controller.js
@@ -117,8 +117,8 @@ const activateListing = async (req, res) => {
     const curr = new Date();
     const field = curr.getMonth() + 1 + "/" + curr.getDate();
     await Housekeeping.findOneAndUpdate(
-      { name: "activeListings" },
-      { $inc: { ["payload." + field]: 1 } }
+      { name: "activeListings", "payload.date": field },
+      { $inc: { "payload.$.count": 1 } }
     );
 
     return res.status(200).json({

--- a/helpers/account.helper.js
+++ b/helpers/account.helper.js
@@ -5,8 +5,8 @@ const incHousekeepingUsers = async () => {
   const curr = new Date();
   const field = curr.getMonth() + 1 + "/" + curr.getDate();
   await Housekeeping.findOneAndUpdate(
-    { name: "users" },
-    { $inc: { ["payload." + field]: 1 } }
+    { name: "users", "payload.date": field },
+    { $inc: { "payload.$.count": 1 } }
   );
 };
 

--- a/models/housekeeping.model.js
+++ b/models/housekeeping.model.js
@@ -6,9 +6,9 @@ const HousekeepingSchema = new Schema({
     required: true,
   },
   payload: {
-    type: Object,
+    type: Array,
     required: true,
-    default: {},
+    default: [],
   },
 });
 


### PR DESCRIPTION
<!--- 1) Your PR has a descriptive name --->
<!--- 2) This PR template is filled out --->
<!--- 3) You wrote tests for your change --->

# Relevant issue
<!--- Put the issue number here. --->
Closes #131 

# Summary of change
- Note: There may be a possibility that my data structure change could've affected other parts of code so highly advise to do a in-depth code review. 
- Updated the data structure in MongoDB from being an object filled with multiple keys (date) and values (count), it is now an array of objects where each object stores a date and a count key-value pair.
- Changing this data structure allows for the previous count to be easily referenced based on index number rather than yesterday's date.

# Testing/Verification
- Make sure to call the "resetDayCount" in app.js to execute the necessary functions without having to call the corn job (as illustrated in the photo).
- To test if the count persists for days that arent sequential, just change the current date in the "taskScheduler" file by doing the following const date = curr.getDate() + 5; (This will make the current day to 5 days in advanced). This should push a new object in MongoDB also check photo).
- To check if the count works, you can create a new listing and/or signup a new user.

![resetDayCounnt](https://user-images.githubusercontent.com/76442800/134792383-ab0b644d-913e-4edf-8c04-2d4ff2c6a0b6.png)
![TaskScheduler](https://user-images.githubusercontent.com/76442800/134792384-7d80635f-5ae2-4474-bbc9-ffa1d8fcce2e.png)
![HousekeepingData](https://user-images.githubusercontent.com/76442800/134792546-e4fed151-2a3f-45f6-9e44-9d757a8b7379.png)

