### PR TITLE
Prevented Popularity VisitCount from being <= 0

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,9 +7,6 @@ const cron = require("node-cron");
 const path = require("path");
 const { allCronJobs } = require("./helpers/cronJobs.helper");
 
-//For Testing purposes of housekeeping remove after done testing.
-const resetDayCount = require("./config/taskScheduler");
-
 const { DATABASE_URI, environment } = require("./config");
 const loginRouter = require("./routes/login");
 const signUpRouter = require("./routes/signup");

--- a/app.js
+++ b/app.js
@@ -7,6 +7,9 @@ const cron = require("node-cron");
 const path = require("path");
 const { allCronJobs } = require("./helpers/cronJobs.helper");
 
+//For Testing purposes of housekeeping remove after done testing.
+const resetDayCount = require("./config/taskScheduler");
+
 const { DATABASE_URI, environment } = require("./config");
 const loginRouter = require("./routes/login");
 const signUpRouter = require("./routes/signup");
@@ -29,6 +32,9 @@ const pingRouter = require("./routes/ping");
 const housekeepingRouter = require("./routes/housekeeping");
 
 const app = express();
+
+resetDayCount();
+
 app.use(bodyParser.json());
 app.use(cors({ origin: true }));
 app.use(morgan("dev"));

--- a/app.js
+++ b/app.js
@@ -33,8 +33,6 @@ const housekeepingRouter = require("./routes/housekeeping");
 
 const app = express();
 
-resetDayCount();
-
 app.use(bodyParser.json());
 app.use(cors({ origin: true }));
 app.use(morgan("dev"));

--- a/config/taskScheduler.js
+++ b/config/taskScheduler.js
@@ -31,7 +31,7 @@ const resetPopularityCount = async () => {
     });
   });
 
-  await Popularity.deleteMany({ visitCount: 0 }, (err) => {
+  await Popularity.deleteMany({ visitCount: { $lt: 1 } }, (err) => {
     if (err) {
       console.log("There was an error while deleting");
     } else {

--- a/config/taskScheduler.js
+++ b/config/taskScheduler.js
@@ -2,7 +2,7 @@ const Popularity = require("../models/popularity.model");
 const Housekeeping = require("../models/housekeeping.model");
 
 const resetDayCount = async () => {
-  await resetPopularityCount();
+  // await resetPopularityCount();
   await resetHousekeepingCount();
 };
 
@@ -48,21 +48,34 @@ const resetHousekeepingCount = async () => {
     const month = curr.getMonth() + 1; // to deal with javascript off by 1 for month
     const field = month + "/" + date;
 
-    const yesterday = new Date();
-    yesterday.setDate(curr.getDate() - 1);
-    const oldDate = yesterday.getDate();
-    const oldMonth = yesterday.getMonth() + 1;
-    const oldField = oldMonth + "/" + oldDate;
-
     const helperFunc = async (name) => {
       const oldResult = await Housekeeping.findOne({ name });
-      let oldPayload = oldResult.payload[oldField];
-      if (!oldPayload) {
-        oldPayload = 0;
+      let oldIndex = oldResult.payload.length - 1; //Gets the last array element from the payload
+      let oldCount;
+      let oldDay;
+
+      //Checks if there are zero objects in array.
+      if (oldIndex === -1) {
+        oldCount = 0;
+      } else {
+        //Gets the previous object's count in the array.
+        oldCount = oldResult.payload[oldIndex].count;
+        oldDay = oldResult.payload[oldIndex].date;
       }
+
+      /*Prevents the housekeeping from pushing a new object (mostly for testing purposes since the cron job will only run once each day.*/
+      if (field === oldDay) {
+        return;
+      }
+
+      //Pushes a new payload object to keep track of the date and count
       await Housekeeping.findOneAndUpdate(
         { name },
-        { $set: { ["payload." + field]: oldPayload } }
+        {
+          $push: {
+            payload: { date: field, count: oldCount },
+          },
+        }
       );
     };
 

--- a/config/taskScheduler.js
+++ b/config/taskScheduler.js
@@ -2,7 +2,7 @@ const Popularity = require("../models/popularity.model");
 const Housekeeping = require("../models/housekeeping.model");
 
 const resetDayCount = async () => {
-  // await resetPopularityCount();
+  await resetPopularityCount();
   await resetHousekeepingCount();
 };
 

--- a/controllers/housekeeping.controller.js
+++ b/controllers/housekeeping.controller.js
@@ -4,6 +4,8 @@ const getName = async (req, res) => {
   try {
     const { name } = req.params;
     const result = await Housekeeping.findOne({ name });
+    /*This originally sent back the object with all the fields from the payload,
+      but now returns an array of objects as the payload.*/
     res.status(200).json({ payload: result.payload });
   } catch (err) {
     res.status(500).json({

--- a/controllers/listing.controller.js
+++ b/controllers/listing.controller.js
@@ -117,8 +117,8 @@ const activateListing = async (req, res) => {
     const curr = new Date();
     const field = curr.getMonth() + 1 + "/" + curr.getDate();
     await Housekeeping.findOneAndUpdate(
-      { name: "activeListings" },
-      { $inc: { ["payload." + field]: 1 } }
+      { name: "activeListings", "payload.date": field },
+      { $inc: { "payload.$.count": 1 } }
     );
 
     return res.status(200).json({

--- a/helpers/account.helper.js
+++ b/helpers/account.helper.js
@@ -5,8 +5,8 @@ const incHousekeepingUsers = async () => {
   const curr = new Date();
   const field = curr.getMonth() + 1 + "/" + curr.getDate();
   await Housekeeping.findOneAndUpdate(
-    { name: "users" },
-    { $inc: { ["payload." + field]: 1 } }
+    { name: "users", "payload.date": field },
+    { $inc: { "payload.$.count": 1 } }
   );
 };
 

--- a/models/housekeeping.model.js
+++ b/models/housekeeping.model.js
@@ -6,9 +6,9 @@ const HousekeepingSchema = new Schema({
     required: true,
   },
   payload: {
-    type: Object,
+    type: Array,
     required: true,
-    default: {},
+    default: [],
   },
 });
 


### PR DESCRIPTION
<!--- BEFORE SUBMITTING YOUR PR, CHECK THAT: --->
<!--- 1) Your PR has a descriptive name --->
<!--- 2) This PR template is filled out --->
<!--- 3) You wrote tests for your change --->

# Relevant issue
<!--- Put the issue number here. --->
Closes #151 

# Summary of change
<!--- Describe the change that this pull request makes. --->
<!--- Add screenshots here if relevant --->
- Made all popularity documents that had a visit count <1 be deleted in the popularity collection.
- However, I haven't fully implemented a solution for removing popularity documents for deleted listings because the deactivate listing feature doesn't seem to work on the frontend.

# Testing/Verification
<!--- How did you test your change? Reference any files you changed/added here. --->
- To test you have to make sure you call the resetDayCount() method in app.js like shown in the image
- Then go to the "taskScheduler.js" file and locate the method "resetPopularityCount" method. In this method, you can change the "currDay = new Date().getDay();" by adding or subtracting an integer value eg. "currDay = new Date().getDay() - 1;". The currDay represents the index value of array "visits" in each of the popularity documents (as seen in the photo).
- After you changed the currDay value and recompiled the program, the method should set the integer value (in the array pertaining to the specific currDay index) to 0. 
- If you make all of the values in the index 0, the "visitCount" property will then also be zero resulting in the document being deleted in the popularity collection.
- Note you'll have to do a bit of refreshing on MongoDB to notice each of the changes that occur when you make changes to the backend
![image](https://user-images.githubusercontent.com/76442800/137424045-0be3d46b-07d0-4214-89a8-3af1aff6366a.png)
![image](https://user-images.githubusercontent.com/76442800/137424361-6c61f85c-3cb8-419d-a7d9-d6956f913a52.png)
